### PR TITLE
ROS 2 Lyrical 対応と潜在バグ修正

### DIFF
--- a/.github/workflows/ci_lyrical.yaml
+++ b/.github/workflows/ci_lyrical.yaml
@@ -1,0 +1,40 @@
+name: ci_lyrical
+
+on:
+  push:
+    branches:
+      - "lyrical"
+      - "lyrical_dev"
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    if: |
+      ((github.event.action == 'labeled') && (github.event.label.name == 'TESTING') && (github.base_ref == 'lyrical' )) ||
+      ((github.event.action == 'synchronize') && (github.base_ref == 'lyrical') && contains(github.event.pull_request.labels.*.name, 'TESTING')) ||
+      (github.ref_name == 'lyrical') || (github.ref_name == 'lyrical_dev')
+    container:
+      image: osrf/ros:${{ matrix.ros_distribution }}-desktop
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        ros_distribution: [lyrical]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ matrix.ros_distribution }}
+      - name: Build and Test
+        uses: ros-tooling/action-ros-ci@v0.4
+        with:
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          vcs-repo-file-url: build_depends.repos
+          package-name: |
+            sanehal
+            sanehal_bringup
+            sanehal_vehicle_description

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Project SANEHAL
 
 [![ci_jazzy](https://github.com/MrBearing/sanehal/actions/workflows/ci_jazzy.yaml/badge.svg)](https://github.com/MrBearing/sanehal/actions/workflows/ci_jazzy.yaml)
+[![ci_lyrical](https://github.com/MrBearing/sanehal/actions/workflows/ci_lyrical.yaml/badge.svg)](https://github.com/MrBearing/sanehal/actions/workflows/ci_lyrical.yaml)
 
 ## 事前準備
 

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -2,7 +2,7 @@ repositories:
   dynamixel-hardware:
     type: git
     url: https://github.com/dynamixel-community/dynamixel_hardware
-    version: jazzy
+    version: lyrical
   dynamixel-workbench:
     type: git
     url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git

--- a/sanehal/package.xml
+++ b/sanehal/package.xml
@@ -8,7 +8,6 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <exec_depend>sanehal_vehicle_sandbox</exec_depend>
   <exec_depend>sanehal_vehicle_description</exec_depend>
   
   <export>

--- a/sanehal_bringup/launch/diffbot.launch.py
+++ b/sanehal_bringup/launch/diffbot.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, Node, RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import (
@@ -22,6 +22,7 @@ from launch.substitutions import (
     LaunchConfiguration,
     PathJoinSubstitution,
 )
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -70,15 +71,15 @@ def generate_launch_description():
             '--ros-args',
             '--log-level', logger
         ],
+        remappings=[
+            ('/diffbot_base_controller/cmd_vel', '/cmd_vel'),
+        ],
     )
     robot_state_pub_node = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         output='both',
         parameters=[robot_description],
-        remappings=[
-            ('/diff_drive_controller/cmd_vel_unstamped', '/cmd_vel'),
-        ],
     )
     rviz_node = Node(
         package='rviz2',

--- a/sanehal_bringup/launch/diffbot_on_pi.launch.py
+++ b/sanehal_bringup/launch/diffbot_on_pi.launch.py
@@ -54,15 +54,15 @@ def generate_launch_description():
         parameters=[robot_description, robot_controllers],
         output='both',
         # arguments=['--ros-args', '--log-level', logger]
+        remappings=[
+            ('/diffbot_base_controller/cmd_vel', '/cmd_vel'),
+        ],
     )
     robot_state_pub_node = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         output='both',
         parameters=[robot_description],
-        remappings=[
-            ('/diff_drive_controller/cmd_vel_unstamped', '/cmd_vel'),
-        ],
     )
 
     joint_state_broadcaster_spawner = Node(

--- a/sanehal_vehicle_description/controllers/diffbot_controllers.yaml
+++ b/sanehal_vehicle_description/controllers/diffbot_controllers.yaml
@@ -14,7 +14,6 @@ diffbot_base_controller:
     right_wheel_names: ["right_wheel_joint"]
 
     wheel_separation: 0.288
-    #wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
     wheel_radius: 0.0395 # = 0.079/2
 
     wheel_separation_multiplier: 1.0
@@ -32,24 +31,15 @@ diffbot_base_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: false
     #velocity_rolling_window_size: 10
 
-    linear.x.has_velocity_limits: true
-    linear.x.has_acceleration_limits: true
-    linear.x.has_jerk_limits: false
+    # Limits are enabled by setting a finite value (unset/NaN = disabled)
     linear.x.max_velocity: 20.0
     linear.x.min_velocity: -20.0
     linear.x.max_acceleration: 18.0
-    linear.x.max_jerk: 0.0
-    linear.x.min_jerk: 0.0
+    linear.x.max_deceleration: 18.0
 
-    angular.z.has_velocity_limits: true
-    angular.z.has_acceleration_limits: true
-    angular.z.has_jerk_limits: false
     angular.z.max_velocity: 135.0
     angular.z.min_velocity: -135.0
     angular.z.max_acceleration: 1.0
-    angular.z.min_acceleration: -1.0
-    angular.z.max_jerk: 0.0
-    angular.z.min_jerk: 0.0
+    angular.z.max_deceleration: 1.0


### PR DESCRIPTION
## 概要

ROS 2 Lyrical Luth (Ubuntu 26.04) への対応と、確認中に見つかった潜在バグの修正。

## 変更内容

### Lyrical 対応
- **ci_lyrical.yaml を新規追加**: `osrf/ros:lyrical-desktop` コンテナでビルド・テストする workflow（ci_jazzy.yaml と同構成、actions は checkout@v4 / setup-ros@v0.7 / action-ros-ci@v0.4 に更新）
- **build_depends.repos**: dynamixel_hardware を `lyrical` ブランチに切り替え
- **diffbot_controllers.yaml**: Lyrical の diff_drive_controller 仕様に更新
  - 削除された `use_stamped_vel` / `has_*_limits` フラグを除去（有限値の設定でリミット有効化）
  - `min_acceleration` を `max_deceleration` に置き換え
- **cmd_vel remap**: 存在しない `cmd_vel_unstamped` への remap（robot_state_publisher に付いており元々無効だった）を削除し、controller_manager ノードに `/diffbot_base_controller/cmd_vel` → `/cmd_vel` の remap を追加（Lyrical は TwistStamped の `~/cmd_vel` のみ受付）
- README に ci_lyrical バッジ追加

### 潜在バグ修正（全ディストロ共通）
- **diffbot.launch.py**: `Node` を `launch.actions` から import しており ImportError で必ず失敗していた → `launch_ros.actions` に修正
- **sanehal/package.xml**: 削除済みパッケージ `sanehal_vehicle_sandbox` への exec_depend を削除（rosdep 失敗の原因）

## レビュー時の注意

- ldlidar_stl_ros2 (jazzy) / ldlidar_stl_utils (humble) は lyrical ブランチが無いため既存ブランチのまま → #19
- .vscode/settings.json は jazzy 前提のまま → #20
- 実機未検証 → #21
- base の `lyrical` ブランチは jazzy から新設したディストロ別ブランチ

🤖 Generated with [Claude Code](https://claude.com/claude-code)